### PR TITLE
Skip key "act" from sign function

### DIFF
--- a/Nihaopay/callback.php
+++ b/Nihaopay/callback.php
@@ -8,7 +8,7 @@ function sign($params, $token) {
   ksort($params);
   $sign_str = [];
   foreach ($params as $key => $val) {
-    if ($key == 'verify_sign' || $val == null || $val == '' || $val == 'null') continue;
+    if ($key == 'act' || $key == 'verify_sign' || $val == null || $val == '' || $val == 'null') continue;
     array_push($sign_str, "$key=$val");
   }
   $sign_str = implode('&', $sign_str);


### PR DESCRIPTION
In the current state the sign function does not calculate the same value as being returned by the payment gateway.

Skipping the key "act" allows the signing to be the same as being returned. And therefore continue passed line 18 > $_REQUEST['verify_sign'] != sign($_REQUEST, NIHAOPAY_TOKEN)